### PR TITLE
Query Node Parameters

### DIFF
--- a/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
@@ -262,7 +262,6 @@ protected:
   std::function<rclcpp::Time()> now_fn_;
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_;
   rclcpp::Logger logger_;
-  QueryParams query_params_;
 
   // Execution model
   std::atomic_bool shutdown_ = false;
@@ -270,6 +269,8 @@ protected:
   std::thread watch_thread_;
   Event update_event_;
   std::function<void()> graph_change_callback_;
+
+  QueryParams query_params_;
 
   // Graph cache
   std::unordered_map<std::string, NodeTracking> nodes_;

--- a/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
@@ -15,6 +15,8 @@
 #ifndef ROSGRAPH_MONITOR__MONITOR_HPP_
 #define ROSGRAPH_MONITOR__MONITOR_HPP_
 
+#include <future>
+#include <functional>
 #include <thread>
 #include <map>
 #include <memory>
@@ -25,9 +27,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <future>
-#include <functional>
-#include <atomic>
 
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "diagnostic_updater/diagnostic_status_wrapper.hpp"
@@ -177,6 +176,8 @@ protected:
     bool missing = false;
     bool stale = false;
     std::vector<ParameterTracking> params;
+
+    explicit NodeTracking(const std::string & name);
   };
 
   /// @brief Keeps aggregate info about a topic as a whole over time

--- a/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
@@ -34,6 +34,7 @@
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/time.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rcl_interfaces/msg/list_parameters_result.hpp"
 #include "rosgraph_monitor_msgs/msg/topic_statistics.hpp"
 #include "rosgraph_monitor_msgs/msg/graph.hpp"
@@ -160,11 +161,12 @@ public:
 protected:
   /* Types */
 
-  struct ParamTracking
+  struct ParameterTracking
   {
     std::string name;
+    uint8_t type;
 
-    rosgraph_monitor_msgs::msg::Parameter to_msg() const;
+    rcl_interfaces::msg::ParameterDescriptor to_msg() const;
   };
 
 
@@ -174,7 +176,7 @@ protected:
     std::string name;
     bool missing = false;
     bool stale = false;
-    std::vector<ParamTracking> params;
+    std::vector<ParameterTracking> params;
   };
 
   /// @brief Keeps aggregate info about a topic as a whole over time

--- a/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <future>
 #include <functional>
+#include <atomic>
 
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "diagnostic_updater/diagnostic_status_wrapper.hpp"

--- a/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
@@ -25,12 +25,15 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <future>
+#include <functional>
 
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "diagnostic_updater/diagnostic_status_wrapper.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/time.hpp"
+#include "rcl_interfaces/msg/list_parameters_result.hpp"
 #include "rosgraph_monitor_msgs/msg/topic_statistics.hpp"
 #include "rosgraph_monitor_msgs/msg/graph.hpp"
 #include "rosgraph_monitor_msgs/msg/qos_profile.hpp"

--- a/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
@@ -42,7 +42,8 @@ typedef std::array<uint8_t, RMW_GID_STORAGE_SIZE> RosRmwGid;
 typedef std::shared_future<void> QueryParamsReturnType;
 typedef std::function<QueryParamsReturnType(
       const std::string & node_name,
-      std::function<void (const rcl_interfaces::msg::ListParametersResult &)> callback)> QueryParams;
+      std::function<void (const rcl_interfaces::msg::ListParametersResult &)>
+      callback)> QueryParams;
 
 /// @brief Provide a std::hash specialization so we can use RMW GID as a map key
 template<>

--- a/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
@@ -34,6 +34,7 @@
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/time.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rcl_interfaces/msg/parameter_type.hpp"
 #include "rcl_interfaces/msg/list_parameters_result.hpp"
 #include "rosgraph_monitor_msgs/msg/topic_statistics.hpp"
 #include "rosgraph_monitor_msgs/msg/graph.hpp"

--- a/rosgraph_monitor/include/rosgraph_monitor/node.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/node.hpp
@@ -17,6 +17,8 @@
 
 #include <memory>
 #include <vector>
+#include <string>
+#include <unordered_map>
 
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
@@ -43,7 +45,10 @@ protected:
   void update_params(const rosgraph_monitor::Params & params);
   void on_topic_statistics(const rosgraph_monitor_msgs::msg::TopicStatistics::SharedPtr msg);
   void publish_diagnostics();
-  void publish_rosgraph();
+  void publish_rosgraph(rosgraph_monitor_msgs::msg::Graph rosgraph_msg);
+  QueryParamsReturnType query_params(
+    const std::string & node_name,
+    std::function<void(const rcl_interfaces::msg::ListParametersResult &)> callback);
 
   rosgraph_monitor::ParamListener param_listener_;
   rosgraph_monitor::Params params_;
@@ -55,6 +60,8 @@ protected:
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diagnostics_;
   rclcpp::Publisher<rosgraph_monitor_msgs::msg::Graph>::SharedPtr pub_rosgraph_;
   rclcpp::TimerBase::SharedPtr timer_publish_report_;
+
+  std::unordered_map<std::string, rclcpp::AsyncParametersClient> param_clients_;
 };
 
 }  // namespace rosgraph_monitor

--- a/rosgraph_monitor/include/rosgraph_monitor/node.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/node.hpp
@@ -33,6 +33,8 @@
 namespace rosgraph_monitor
 {
 
+constexpr int SERVICE_TIMEOUT_S = 5;
+
 class Node : public rclcpp::Node
 {
 private:

--- a/rosgraph_monitor/include/rosgraph_monitor/node.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/node.hpp
@@ -23,6 +23,7 @@
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "rclcpp/node.hpp"
+#include "rclcpp/parameter_client.hpp"
 #include "rosgraph_monitor_msgs/msg/graph.hpp"
 #include "rosgraph_monitor_msgs/msg/topic_statistics.hpp"
 
@@ -61,7 +62,7 @@ protected:
   rclcpp::Publisher<rosgraph_monitor_msgs::msg::Graph>::SharedPtr pub_rosgraph_;
   rclcpp::TimerBase::SharedPtr timer_publish_report_;
 
-  std::unordered_map<std::string, rclcpp::AsyncParametersClient> param_clients_;
+  std::unordered_map<std::string, std::shared_ptr<rclcpp::AsyncParametersClient>> param_clients_;
 };
 
 }  // namespace rosgraph_monitor

--- a/rosgraph_monitor/include/rosgraph_monitor/node.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/node.hpp
@@ -16,14 +16,12 @@
 #define ROSGRAPH_MONITOR__NODE_HPP_
 
 #include <memory>
-#include <vector>
 #include <string>
-#include <unordered_map>
+#include <vector>
 
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "rclcpp/node.hpp"
-#include "rclcpp/parameter_client.hpp"
 #include "rosgraph_monitor_msgs/msg/graph.hpp"
 #include "rosgraph_monitor_msgs/msg/topic_statistics.hpp"
 
@@ -63,8 +61,6 @@ protected:
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diagnostics_;
   rclcpp::Publisher<rosgraph_monitor_msgs::msg::Graph>::SharedPtr pub_rosgraph_;
   rclcpp::TimerBase::SharedPtr timer_publish_report_;
-
-  std::unordered_map<std::string, std::shared_ptr<rclcpp::AsyncParametersClient>> param_clients_;
 };
 
 }  // namespace rosgraph_monitor

--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -721,7 +721,12 @@ void RosGraphMonitor::query_node_parameters(const std::string & node_name)
       RCLCPP_INFO(
         logger_, "Got parameters for node %s: %zu", node_name_copy.c_str(),
         result.names.size());
-      auto & tracking = nodes_[node_name_copy];
+      auto it = nodes_.find(node_name_copy);
+      if (it == nodes_.end()) {
+        RCLCPP_WARN(logger_, "Node %s not found in tracking map", node_name_copy.c_str());
+        return;
+      }
+      auto & tracking = it->second;
       tracking.params.clear();
       tracking.params.reserve(result.names.size());
       for (const auto & param_name : result.names) {

--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -722,8 +722,9 @@ void RosGraphMonitor::query_node_parameters(const std::string & node_name)
         result.names.size());
       auto & tracking = nodes_[node_name_copy];
       for (const auto & param_name : result.names) {
-        tracking.params.push_back(ParameterTracking{param_name,
-        rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET});
+        tracking.params.push_back(
+          ParameterTracking{param_name,
+            rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET});
       }
       if (!tracking.params.empty()) {
         // Although the querying of node parameters doesn't necessarily

--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -22,7 +22,6 @@
 #include <memory>
 
 #include "rclcpp/logging.hpp"
-#include "rclcpp/parameter_client.hpp"
 
 
 std::size_t std::hash<RosRmwGid>::operator()(
@@ -136,6 +135,10 @@ rcl_interfaces::msg::ParameterDescriptor RosGraphMonitor::ParameterTracking::to_
   return param_msg;
 }
 
+
+RosGraphMonitor::NodeTracking::NodeTracking(const std::string & name)
+: name(name) {}
+
 RosGraphMonitor::EndpointTracking::EndpointTracking(
   const std::string & topic_name,
   const rclcpp::TopicEndpointInfo & info,
@@ -226,9 +229,7 @@ void RosGraphMonitor::track_node_updates(
       continue;
     }
 
-    NodeTracking tracking{};
-    tracking.name = node_name;
-
+    NodeTracking tracking{node_name};
     auto [it, inserted] = nodes_.emplace(
       node_name, tracking);
 
@@ -729,10 +730,6 @@ void RosGraphMonitor::query_node_parameters(const std::string & node_name)
             rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET});
       }
       if (!tracking.params.empty()) {
-        // Although the querying of node parameters doesn't necessarily
-        // qualify as a graph change in of itself, our **knowledge** of the
-        // graph has changed and therefore qualifies as a graph change
-        // event.
         graph_change_callback_();
       }
     });

--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -224,8 +224,8 @@ void RosGraphMonitor::track_node_updates(
       continue;
     }
 
-     NodeTracking tracking{};
-     tracking.name = node_name;
+    NodeTracking tracking{};
+    tracking.name = node_name;
 
     auto [it, inserted] = nodes_.emplace(
       node_name, tracking);

--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -721,6 +721,8 @@ void RosGraphMonitor::query_node_parameters(const std::string & node_name)
         logger_, "Got parameters for node %s: %zu", node_name_copy.c_str(),
         result.names.size());
       auto & tracking = nodes_[node_name_copy];
+      tracking.params.clear();
+      tracking.params.reserve(result.names.size());
       for (const auto & param_name : result.names) {
         tracking.params.push_back(
           ParameterTracking{param_name,

--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -127,10 +127,12 @@ rosgraph_monitor_msgs::msg::QosProfile to_msg(
   return qos_msg;
 }
 
-rosgraph_monitor_msgs::msg::Parameter RosGraphMonitor::ParamTracking::to_msg() const
+rcl_interfaces::msg::ParameterDescriptor RosGraphMonitor::ParameterTracking::to_msg() const
 {
-  rosgraph_monitor_msgs::msg::Parameter param_msg;
+  rcl_interfaces::msg::ParameterDescriptor param_msg;
   param_msg.name = name;
+  // TODO(troy): Actual type info will be populated in future PR
+  param_msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET;
   return param_msg;
 }
 
@@ -720,7 +722,7 @@ void RosGraphMonitor::query_node_parameters(const std::string & node_name)
         result.names.size());
       auto & tracking = nodes_[node_name_copy];
       for (const auto & param_name : result.names) {
-        tracking.params.push_back(ParamTracking{param_name});
+        tracking.params.push_back(ParameterTracking{param_name});
       }
       if (!tracking.params.empty()) {
         // Although the querying of node parameters doesn't necessarily

--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -722,7 +722,8 @@ void RosGraphMonitor::query_node_parameters(const std::string & node_name)
         result.names.size());
       auto & tracking = nodes_[node_name_copy];
       for (const auto & param_name : result.names) {
-        tracking.params.push_back(ParameterTracking{param_name});
+        tracking.params.push_back(ParameterTracking{param_name,
+        rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET});
       }
       if (!tracking.params.empty()) {
         // Although the querying of node parameters doesn't necessarily

--- a/rosgraph_monitor/src/node.cpp
+++ b/rosgraph_monitor/src/node.cpp
@@ -105,7 +105,6 @@ void Node::update_params(const rosgraph_monitor::Params & params)
   graph_monitor_.config() = create_graph_monitor_config(params_);
 }
 
-// TODO(troy): Perhaps we should have some retry logic here?
 std::shared_future<void> Node::query_params(
   const std::string & node_name,
   std::function<void(const rcl_interfaces::msg::ListParametersResult &)> callback)

--- a/rosgraph_monitor/src/node.cpp
+++ b/rosgraph_monitor/src/node.cpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "rclcpp/node.hpp"
+#include "rclcpp/parameter_client.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 #include "rosgraph_monitor_msgs/msg/graph.hpp"
 #include "rosgraph_monitor_msgs/msg/topic_statistics.hpp"

--- a/rosgraph_monitor_msgs/CMakeLists.txt
+++ b/rosgraph_monitor_msgs/CMakeLists.txt
@@ -32,6 +32,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/NodeInfo.msg
   msg/Graph.msg
   msg/QosProfile.msg
+  msg/Parameter.msg
   msg/Topic.msg
   msg/TopicStatistic.msg
   msg/TopicStatistics.msg

--- a/rosgraph_monitor_msgs/CMakeLists.txt
+++ b/rosgraph_monitor_msgs/CMakeLists.txt
@@ -24,20 +24,21 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   msg/NodeInfo.msg
   msg/Graph.msg
   msg/QosProfile.msg
-  msg/Parameter.msg
   msg/Topic.msg
   msg/TopicStatistic.msg
   msg/TopicStatistics.msg
   DEPENDENCIES
   builtin_interfaces
+  rcl_interfaces
 )
 
 if(BUILD_TESTING)

--- a/rosgraph_monitor_msgs/msg/NodeInfo.msg
+++ b/rosgraph_monitor_msgs/msg/NodeInfo.msg
@@ -3,3 +3,5 @@ string name
 
 Topic[] publishers
 Topic[] subscriptions
+
+Parameter[] parameters

--- a/rosgraph_monitor_msgs/msg/NodeInfo.msg
+++ b/rosgraph_monitor_msgs/msg/NodeInfo.msg
@@ -4,4 +4,9 @@ string name
 Topic[] publishers
 Topic[] subscriptions
 
-Parameter[] parameters
+# Observed parameter descriptions and current values for this node
+# parameter_values[] must be the same size as parameters[], or empty
+# Empty on either array means no values have yet been successfully queried
+# When set, parameter_values[] match up 1:1 with the same index in parameters[]
+rcl_interfaces/ParameterDescriptor[] parameters
+rcl_interfaces/ParameterValue[] parameter_values

--- a/rosgraph_monitor_msgs/msg/Parameter.msg
+++ b/rosgraph_monitor_msgs/msg/Parameter.msg
@@ -1,4 +1,0 @@
-# Message representing a single ROS2 parameter
-# TODO: Add descriptor and value
-
-string name

--- a/rosgraph_monitor_msgs/msg/Parameter.msg
+++ b/rosgraph_monitor_msgs/msg/Parameter.msg
@@ -1,0 +1,4 @@
+# Message representing a single ROS2 parameter
+# TODO: Add descriptor and value
+
+string name

--- a/rosgraph_monitor_test/test/test_graph_monitor_launch.py
+++ b/rosgraph_monitor_test/test/test_graph_monitor_launch.py
@@ -21,9 +21,10 @@ from launch.substitutions import PathSubstitution
 from launch_ros.substitutions import FindPackageShare
 from launch_testing.actions import ReadyToTest
 import pytest
+from rcl_interfaces.msg import ParameterDescriptor
 import rclpy
 from rclpy.qos import QoSProfile
-from rosgraph_monitor_msgs.msg import Graph, Parameter, QosProfile as QosProfileMsg
+from rosgraph_monitor_msgs.msg import Graph, QosProfile as QosProfileMsg
 from rosgraph_monitor_test.test_utils import (
     create_random_node_name, find_node, wait_for_message_sync
 )
@@ -234,10 +235,10 @@ class TestProcessOutput(unittest.TestCase):
             # Assert on the parameters
             self.assertCountEqual(
                 list(filter(filter_params,  updated_node.parameters)), [
-                    Parameter(
+                    ParameterDescriptor(
                         name='param1',
                     ),
-                    Parameter(
+                    ParameterDescriptor(
                         name='param2',
                     ),
                 ],

--- a/rosgraph_monitor_test/test/test_graph_monitor_launch.py
+++ b/rosgraph_monitor_test/test/test_graph_monitor_launch.py
@@ -227,18 +227,19 @@ class TestProcessOutput(unittest.TestCase):
             if not len(updated_node.parameters) > 0:
                 return False
 
+            def filter_params(param):
+                return param.name != 'use_sim_time' and \
+                       param.name != 'start_type_description_service'
+
             # Assert on the parameters
             self.assertCountEqual(
-                updated_node.parameters, [
+                list(filter(filter_params,  updated_node.parameters)), [
                     Parameter(
                         name='param1',
                     ),
                     Parameter(
                         name='param2',
                     ),
-                    Parameter(
-                        name='use_sim_time',
-                    )
                 ],
             )
             return True

--- a/rosgraph_monitor_test/test/test_graph_monitor_launch.py
+++ b/rosgraph_monitor_test/test/test_graph_monitor_launch.py
@@ -221,7 +221,6 @@ class TestProcessOutput(unittest.TestCase):
         def parameters_condition(msg):
             # Find the parameter node
             updated_node = find_node(msg, node_name)
-            print(f'Found node: {updated_node.name if updated_node else "None"}')
             if not updated_node:
                 return False
 

--- a/rosgraph_monitor_test/test/test_graph_monitor_launch.py
+++ b/rosgraph_monitor_test/test/test_graph_monitor_launch.py
@@ -23,7 +23,7 @@ from launch_testing.actions import ReadyToTest
 import pytest
 import rclpy
 from rclpy.qos import QoSProfile
-from rosgraph_monitor_msgs.msg import Graph, QosProfile as QosProfileMsg, Parameter
+from rosgraph_monitor_msgs.msg import Graph, Parameter, QosProfile as QosProfileMsg
 from rosgraph_monitor_test.test_utils import (
     create_random_node_name, find_node, wait_for_message_sync
 )
@@ -237,7 +237,7 @@ class TestProcessOutput(unittest.TestCase):
                         name='param2',
                     ),
                     Parameter(
-                        name="use_sim_time",
+                        name='use_sim_time',
                     )
                 ],
             )


### PR DESCRIPTION
## Description

Closes #28 

Populate the `/rosgraph` with parameter names for each node. 

This change had to be done carefully as to not block the main loop tracking node updates, instead preferring to launch on a separate thread (`std::launch::async`) and holding onto the futures in a separate data structure (`params_futures`) so the promises didn't go out of scope as our node introspection logic looped. Currently the parameters querying logic loops indefinitely until the parameters are received (or the node is brought down)

Regarding query retries as mentioned [here](https://github.com/ros-tooling/graph-monitor/pull/24#discussion_r2226375954), I opted instead for a long wait time for the service client and service call to resolve (5 seconds), which felt functionally equivalent. Open to alternatives here.

Out of scope for this change:
- **Value and descriptors**. Should be next up!
- **Subscriptions on `/parameter_events` per node.** I could see the case for including them here, but I thought the change large enough already, and the parameter events are only __really__ useful when the values are updated. 

## Test Plan

I've added the basic happy path tests here, expecting the basic params to be populated in subsequent graph message updates. 

Acquiring the correct published rosgraph message was tricky in assertions that incrementally requested the latest `/rosgraph` message and popped the next from queue. I discovered that incremental requests of the message resulted in flakiness across ~100 test reruns (`--gtest_repeat=100`). Instead, I opted to add some conditional await logic (`await_graphmon_msg_until`). 
