### PR TITLE
Align rosgraph_monitor_test version

### DIFF
--- a/rosgraph_monitor_test/package.xml
+++ b/rosgraph_monitor_test/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosgraph_monitor_test</name>
-  <version>0.1.0</version>
+  <version>0.1.2</version>
   <description>Test package for rosgraph_monitor containing launch tests and test utilities</description>
   <maintainer email="troy@polymathrobotics.com">Troy Gibb</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## Description

Tried to run `catkin_prepare_release --bump minor` and got:

```sh
Prepare the source repository for a release.
Repository type: git
Found packages: rosgraph_monitor_msgs, rosgraph_monitor_test, rosgraph_monitor, rmw_stats_shim
Two packages have different version numbers (0.1.0 != 0.1.2):
- ./rosgraph_monitor_test/package.xml
- ./rosgraph_monitor_msgs/package.xml
```

I must have missed the package version alignment when I first introduced the package.