### PR TITLE
Fix race condition in StatCollector destructor

### DIFF
--- a/rmw_stats_shim/CHANGELOG.rst
+++ b/rmw_stats_shim/CHANGELOG.rst
@@ -1,6 +1,13 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package rmw_stats_shim
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Forthcoming
+-----------
+* Use ros_environment to detect distro instead of ament_cmake version (`#39 <https://github.com/ros-tooling/graph-monitor/pull/39>`_)
+* Add documentation skeleton for all released packages (`#44 <https://github.com/ros-tooling/graph-monitor/pull/44>`_)
+* Add new methods added to graph interface in Rolling (`#48 <https://github.com/ros-tooling/graph-monitor/pull/48>`_)
+* Fix race condition in StatCollector destructor (`#50 <https://github.com/ros-tooling/graph-monitor/pull/50>`_)
+* Contributors: Emerson Knapp, shrujan, Skyler Medeiros
 
 0.2.3 (2025-10-22)
 ------------------

--- a/rmw_stats_shim/include/rmw_stats_shim/timer.hpp
+++ b/rmw_stats_shim/include/rmw_stats_shim/timer.hpp
@@ -15,6 +15,7 @@
 #ifndef RMW_STATS_SHIM__TIMER_HPP_
 #define RMW_STATS_SHIM__TIMER_HPP_
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -57,7 +58,7 @@ private:
   std::function<void(void)> func_;
   std::chrono::milliseconds interval_;
   std::thread thread_;
-  bool running_ = false;
+  std::atomic<bool> running_ = false;
 };
 
 }  // namespace rmw_stats_shim

--- a/rmw_stats_shim/src/stat_collector.cpp
+++ b/rmw_stats_shim/src/stat_collector.cpp
@@ -324,6 +324,12 @@ StatCollector::StatCollector()
 
 StatCollector::~StatCollector()
 {
+  // Stop the timer first so its thread isn't iterating nodes_/publishers_/subscriptions_
+  // while ~StatPublisher tears them down below. Otherwise publishStatistics() can race
+  // nodes_.clear() and segfault on a freed StatPublisher.
+  if (timer_) {
+    timer_->stop();
+  }
   // It's important to destroy all the StatPublishers before the other member maps.
   // ~StatPublisher calls rmw_destroy_publisher, which triggers a graph event publish,
   // leading to rmw_publish->StatCollector::onPublish,


### PR DESCRIPTION
From repeated stress testing, I uncovered a rare race condition that can lead to a segfault. This PR makes the following multithreaded safety improvements:
- Stop the stat publisher timer before shutdown, so its thread doesn't service destructing entities (node ptrs, subscriptions, publishers)
- Make `Timer::running_` a `std::atomic`