### PR TITLE
Include <cstring>

### DIFF
--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -15,6 +15,7 @@
 #include "rosgraph_monitor/monitor.hpp"
 
 #include <cstdio>
+#include <cstring>
 #include <functional>
 #include <string>
 #include <utility>


### PR DESCRIPTION
Without this, I get the following compile error with GCC 15:

    /build/graph_monitor-release-release-humble-rosgraph_monitor-0.2.3-1/src/monitor.cpp:34:10:
    error: 'memcpy' is not a member of 'std'; did you mean 'wmemcpy'?
       34 |     std::memcpy(&d0, id.data() + (0 * u64s), u64s);
          |          ^~~~~~
          |          wmemcpy