### PR TITLE
Link rmw_stats_shim against Threads

### DIFF
--- a/rmw_stats_shim/CMakeLists.txt
+++ b/rmw_stats_shim/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(rmw REQUIRED)
 find_package(rosgraph_monitor_msgs REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
+find_package(Threads REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/shim.cpp
@@ -45,6 +46,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   rmw::rmw
   rosidl_runtime_cpp::rosidl_runtime_cpp
   rosidl_typesupport_cpp::rosidl_typesupport_cpp
+  Threads::Threads
   ${rosgraph_monitor_msgs_TARGETS}
 )
 


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

This upstreams `patch/ros-rolling-rmw-stats-shim.patch`, authored in RoboStack by cc `<cc7@duck.com>`.

`rmw_stats_shim` builds a shared library and depends on threading support through its dependency stack. Finding Threads and linking `Threads::Threads` makes the thread dependency explicit for platforms and linkers that do not add it implicitly.